### PR TITLE
Added 'acceptInsecureCerts' capability for Firefox

### DIFF
--- a/Src/MvcPages/SeleniumUtils/SeleniumDriverFactory.cs
+++ b/Src/MvcPages/SeleniumUtils/SeleniumDriverFactory.cs
@@ -145,6 +145,9 @@ namespace Tellurium.MvcPages.SeleniumUtils
             {
                 Profile = new FirefoxProfile {DeleteAfterUse = true}
             };
+
+            firefoxGeckoOptions.AddAdditionalCapability("acceptInsecureCerts", true, true);
+
             firefoxGeckoOptions.Profile.EnableFileDownloading(this.config.DownloadDirPath, config.AllowedMimeTypes);
             return firefoxGeckoOptions;
         }
@@ -163,6 +166,9 @@ namespace Tellurium.MvcPages.SeleniumUtils
                 Profile = new FirefoxProfile {DeleteAfterUse = true},
                 UseLegacyImplementation = true
             };
+
+            firefoxOptions.AddAdditionalCapability("acceptInsecureCerts", true, true);
+
             firefoxOptions.Profile.EnableFileDownloading(this.config.DownloadDirPath, this.config.AllowedMimeTypes);
             return firefoxOptions;
         }


### PR DESCRIPTION
Added `acceptInsecureCerts` flag so Tellurium could work on firefox with untrusted certificates